### PR TITLE
Lower dependencies for Rails 3.1 compatibility

### DIFF
--- a/gridhook.gemspec
+++ b/gridhook.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['app', 'lib']
 
-  spec.add_dependency 'rails', '>= 3.2.0'
+  spec.add_dependency 'rails', '>= 3.1.0'
   spec.add_dependency 'yajl-ruby', '~> 1.1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 1.2'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
Thanks for implementing the gem. I am happy to at least remove my own monkey patch and move all the behavior into one single place. Nonetheless I found out it doesn't support 3.1 and apparently I haven't seen any reason against it. I tested within my app and everything seems to work seamlessly (even my own integration tests towards the sendgrid endpoint).
