### PR TITLE
Add Support for basic authentication

### DIFF
--- a/app/controllers/gridhook/events_controller.rb
+++ b/app/controllers/gridhook/events_controller.rb
@@ -1,8 +1,26 @@
 module Gridhook
   class EventsController < ActionController::Base
+
+    before_filter :authenticate
+
     def create
       Gridhook::Event.process(params)
       head :ok
+    end
+
+    private
+
+    def authenticate
+      if Gridhook.config.username || Gridhook.config.password
+        valid_auth = authenticate_with_http_basic do |username, password|
+          Gridhook.config.username == username &&
+          Gridhook.config.password == password
+        end
+
+        unless valid_auth
+          raise (Gridhook.config.auth_error || 'Unauthorized Access')
+        end
+      end
     end
   end
 end

--- a/lib/gridhook/config.rb
+++ b/lib/gridhook/config.rb
@@ -11,7 +11,7 @@ module Gridhook
   end
 
   # This class handles storing Gridhooks configuration variables.
-  class Config < Struct.new(:event_processor, :event_receive_path)
+  class Config < Struct.new(:auth_error, :event_processor, :event_receive_path, :username, :password)
   end
 
 end


### PR DESCRIPTION
Sendgrid's event API supported basic authentication. 

> We support basic HTTP authentication in our Event API. Those who wish to implement can provide credentials in the post event url field on the app settings page. Below is an example of the post url with authentication included.
https://sendgrid.com/docs/API_Reference/Webhooks/event.html

This PR enables setting the allowed username/password for the web hook.