### PR TITLE
Add decorators as engine dependency

### DIFF
--- a/lib/gridhook/engine.rb
+++ b/lib/gridhook/engine.rb
@@ -1,4 +1,9 @@
 module Gridhook
   class Engine < ::Rails::Engine
+    config.to_prepare do
+      Dir.glob(Rails.root + "app/decorators/gridhook/*_decorator*.rb").each do |c|
+        require_dependency(c)
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds possibility to override gridhook-engine methods with decorators in your application.

Example file: app/decorators/gridhook/event_decorator.rb

```ruby
Gridhook::Event.class_eval do
  def self.process_events(events)
    # custom method to process events
  end
end
```